### PR TITLE
Fix registration with multiple bridges

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "hue-register": "./dist/bin/hue-register.js"
   },
   "scripts": {
-    "build": "babel src/ -d dist/",
+    "build": "babel src/ -d dist/ --ignore __tests__",
     "test": "jest",
     "lint": "eslint src",
     "prepublish": "npm run build -- --ignore '__tests__'"
@@ -30,5 +30,10 @@
     "axios": "^0.16.1",
     "hue-bridge-discovery": "^1.1.2",
     "invariant": "^2.2.2"
+  },
+  "jest": {
+    "testPathIgnorePatterns": [
+      "<rootDir>/dist/"
+    ]
   }
 }

--- a/src/bin/__tests__/hue-register.test.js
+++ b/src/bin/__tests__/hue-register.test.js
@@ -1,0 +1,118 @@
+/* eslint-disable no-plusplus */
+import discover from '../../Search';
+import '../hue-register';
+
+jest.useFakeTimers();
+jest.mock('../../Search', () => {
+  const mock = jest.genMockFromModule('../../Search');
+  mock.default.mockReturnValue({
+    cancel: jest.fn(),
+  });
+
+  // Forgive me.
+  process.argv[2] = 'fake-app-name';
+
+  return mock;
+});
+
+const defer = () => {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return {resolve, reject, promise};
+};
+
+describe('Hue register', () => {
+  const [register] = discover.mock.calls[0];
+  const {cancel} = discover();
+  const createConnectionFailError = () => {
+    const error = new Error('Testing failed bridge authentication.');
+    error.code = 101;
+
+    return error;
+  };
+
+  let ip = 1;
+  const createBridge = (shouldAuthenticate = true) => ({
+    ip: ip++,
+    connect: jest.fn(async () => {
+      if (shouldAuthenticate) {
+        return 'tok3n';
+      }
+
+      throw createConnectionFailError();
+    }),
+  });
+
+  beforeEach(() => {
+    cancel.mockReset();
+  });
+
+  it('initiates a search', () => {
+    expect(discover).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('attempts a connection', async () => {
+    const bridge = createBridge();
+    const promise = register(bridge);
+
+    expect(bridge.connect).toHaveBeenCalled();
+
+    await promise;
+  });
+
+  it('retries if the connection fails', async () => {
+    const bridge = createBridge(false);
+    await register(bridge);
+
+    expect(setTimeout).toHaveBeenCalled();
+
+    bridge.connect.mockReset();
+    setTimeout.mock.calls[0][0](bridge);
+
+    expect(bridge.connect).toHaveBeenCalled();
+  });
+
+  it('cancels the search if the connection succeeds', async () => {
+    const bridge = createBridge();
+    await register(bridge);
+
+    expect(cancel).toHaveBeenCalled();
+  });
+
+  it('does not continue pinging other bridges', async () => {
+    setTimeout.mockReturnValue('TIMEOUT_ID');
+    const bridge2 = createBridge(false);
+    const bridge1 = createBridge();
+    bridge2.ip += 1;
+
+    await register(bridge2);
+    await register(bridge1);
+
+    // Already authenticated with bridge1.
+    expect(clearTimeout).toHaveBeenCalledWith('TIMEOUT_ID');
+  });
+
+  // Edge case: two bridges searching, one succeeds and clears the retry
+  // timeouts, but the other is waiting for a bridge response and hasn't
+  // registered for a retry yet.
+  it('stops retrying if another bridge succeeded while in flight', async () => {
+    const bridge2 = createBridge();
+    const bridge1 = createBridge();
+    const deferred = defer();
+    bridge2.connect.mockReturnValue(deferred.promise);
+    bridge2.ip += 1;
+
+    const inFlight = register(bridge2);
+    await register(bridge1);
+
+    setTimeout.mockReset();
+    deferred.reject(createConnectionFailError());
+    await inFlight;
+
+    expect(setTimeout).not.toHaveBeenCalled();
+  });
+});

--- a/src/bin/hue-register.js
+++ b/src/bin/hue-register.js
@@ -1,37 +1,63 @@
 #!/usr/bin/env node
-/* eslint-disable no-console */
 import { hostname } from 'os';
-import Search from '../Search';
+import assert from 'assert';
+
+import discover from '../Search';
 
 const appName = process.argv[2];
-
-if (!appName) {
-  throw new Error('hue-register requires the name of your app.');
-}
+assert(appName, 'hue-register requires the name of your app.');
 
 const deviceName = hostname()
   .replace(/[^a-z0-9 ]/gi, '')
   .replace(/ +/g, '-');
 
-const options = { appName, deviceName };
-const search = new Search(async function register (bridge) {
+const printRegistration = registration => {
+  const serialized = JSON.stringify(registration, null, 2);
+
+  // eslint-disable-next-line no-process-env
+  if (process.env.NODE_ENV !== 'test') {
+
+    // eslint-disable-next-line no-console
+    console.log(serialized);
+  }
+};
+
+const handshakes = Object.create(null);
+
+// Cancelling unnecessary scheduled retries makes the search snappier.
+const cancelAllRetries = () => Object.keys(handshakes).forEach(key => {
+  const handshake = handshakes[key];
+
+  clearTimeout(handshake.retry);
+  handshake.terminated = true;
+});
+
+const search = discover(async function register (bridge) {
+  const handshake = handshakes[bridge.ip] || {bridge, retry: null};
+  handshakes[bridge.ip] = handshake;
+
   try {
-    const token = await bridge.connect(options);
-    const auth = { token, ip: bridge.ip };
-    const data = JSON.stringify(auth, null, 2);
+    const token = await bridge.connect({appName, deviceName});
 
     // Send the result to stdout.
-    console.log(data);
+    printRegistration({token, ip: bridge.ip});
 
     search.cancel();
+    cancelAllRetries();
   } catch (error) {
 
     // No idea what just happened.
     if (error.code !== 101) {
       throw error;
     }
-
-    // Button not pressed. Try again in a moment.
-    setTimeout(() => register(bridge), 1000);
   }
+
+  // Handle cases where termination occured while bridge
+  // registration request was in flight.
+  if (handshake.terminated) {
+    return;
+  }
+
+  // Button not pressed. Try again in a moment.
+  handshake.retry = setTimeout(register, 1000, bridge);
 });


### PR DESCRIPTION
There was a bug in `hue-register.js` where finding more than one bridge
would prevent the process from exiting. It would continue to ping each
bridge until _every one of them_ gave a token. Now it's a bit more
clever about it, preventing requests to other bridges after a token is
received.

Relates to #2 